### PR TITLE
use optimistic version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
     "test": "tap ./test"
   },
   "devDependencies": {
-    "tap": "~0.4.8",
-    "coffee-script": "~1.7.1"
+    "tap": "^0.4.8",
+    "coffee-script": "^1.7.1"
   },
   "keywords": [
     "command line"
   ],
   "dependencies": {
-    "findup-sync": "~0.1.2",
-    "resolve": "~0.6.1",
-    "minimist": "0.0.5",
-    "extend": "~1.2.1"
+    "findup-sync": "^0.1.2",
+    "resolve": "^0.6.1",
+    "minimist": "^0.0.5",
+    "extend": "^1.2.1"
   }
 }


### PR DESCRIPTION
this is the default in npm now

sidenote: why is this module marked as 0.10+?
