### PR TITLE
Run CI with unstable Node.js as an allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
+  - 0.11
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: 0.11


### PR DESCRIPTION
Building against the latest unstable release of Node.js will help the
project maintain awareness of any regressions or breaking changes in the
platform. Specifying that build as an allowed failure guarantees that
unforeseen errors do not block ongoing work.
