### PR TITLE
Look for local module in cwd if no config was found.

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ Liftoff.prototype.buildEnvironment = function (argv) {
   // locate local module and package in config directory
   var modulePath, modulePackage;
   try {
-    modulePath = resolve.sync(this.moduleName, {basedir: configBase});
+    modulePath = resolve.sync(this.moduleName, {basedir: configBase || cwd});
     modulePackage = silentRequire(fileSearch('package.json', [modulePath]));
   } catch (e) {}
 


### PR DESCRIPTION
Looking at the code I believe there should be no side effects. This use case could use a test though, but I was't sure how to proceed. Seems this would warrant testing a different liftoff instance that has no config.

Fixes https://github.com/tkellen/node-liftoff/issues/7
