### PR TITLE
Fix the case of only 1 extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,8 @@ Liftoff.prototype.buildEnvironment = function (argv) {
   var extensions = Object.keys(this.extensions);
   if (configNameRegex instanceof RegExp) {
     configNameRegex = configNameRegex.toString();
+  } else if (extensions.length == 1) {
+    configNameRegex += extensions[0];
   } else {
     configNameRegex += '{'+extensions.join(',')+'}';
   }

--- a/test/index.js
+++ b/test/index.js
@@ -84,7 +84,17 @@ describe('Liftoff', function () {
       expect(test.buildEnvironment().configNameRegex.toString()).to.equal('/mocha/');
     });
 
-    it('should use configName + extensions', function () {
+    it('should use configName + extension for only one extension', function () {
+      var test = new Liftoff({
+        name: NAME,
+        extensions: {
+          '.js': null
+        }
+      });
+      expect(test.buildEnvironment().configNameRegex.toString()).to.equal('mochafile.js');
+    });
+
+    it('should use configName + extensions in brace expansion pattern for 2 or more extensions', function () {
       var test = new Liftoff({
         name: NAME,
         extensions: {


### PR DESCRIPTION
Hi!

I think I found a bug in the creation of `configPathRegex` in index.js.

When the `extensions` parameter has only one entry (for example `.js`), then `configPathRegex` become `mochafile{.js}` (when `configName` is `mochafile`).
But this string is not treated as glob (brace expansion) pattern, but just as the string itself.
So in this case liftoff searches the file `mochafile{.js}` literally, not `mochafile.js`.

This behaviour of `node-findup-sync` (or `node-glob`) doesn't seem a bug because the document of bash says:

> A correctly-formed brace expansion must contain unquoted opening and closing braces, and at least one unquoted comma or a valid sequence expression. Any incorrectly formed brace expansion is left unchanged.

( in https://www.gnu.org/software/bash/manual/html_node/Brace-Expansion.html )

So I suggest this change.

Thanks!
