### PR TITLE
Update npmignore to include artwork

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 test
+artwork


### PR DESCRIPTION
When installing on windows as a dependency of gulp this folder can cause a fail (this is windows fault) and it doesn't seem necessary to have the artwork in the install directory.
