### PR TITLE
feat: expands tilde of extends property in config file to homedir

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var flaggedRespawn = require('flagged-respawn');
 var isPlainObject = require('is-plain-object').isPlainObject;
 var mapValues = require('object.map');
 var fined = require('fined');
+var expandTilde = require('expand-tilde');
 
 var findCwd = require('./lib/find_cwd');
 var arrayFind = require('./lib/array_find');
@@ -106,7 +107,7 @@ Liftoff.prototype.buildEnvironment = function (opts) {
     }
     var configFile;
     try {
-      configFile = require(configFilePath);
+      configFile = require(expandTilde(configFilePath));
     } catch (e) {
       // TODO: Consider surfacing the `require` error
       throw new Error(

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
+    "expand-tilde": "^2.0.2",
     "extend": "^3.0.2",
     "findup-sync": "^5.0.0",
     "fined": "^2.0.0",

--- a/test/fixtures/configfiles-extends/expand-homedir-config.js
+++ b/test/fixtures/configfiles-extends/expand-homedir-config.js
@@ -1,0 +1,14 @@
+var os = require('os');
+var path = require('path');
+
+var absolutePath = path.join(__dirname, './extend-config');
+var relativePath = path.relative(os.homedir(), absolutePath);
+
+if (relativePath !== absolutePath) {
+  relativePath = '~' + path.sep + relativePath;
+}
+
+module.exports = {
+  extends: relativePath,
+  aaa: 'AAA',
+};

--- a/test/index.js
+++ b/test/index.js
@@ -851,6 +851,24 @@ describe('Liftoff', function () {
       });
     });
 
+    it('expands heading `~` in extends property to home dir', function(done) {
+      var app = new Liftoff({
+        name: 'myapp',
+        configFiles: {
+          'expand-homedir-config': ['test/fixtures/configfiles-extends'],
+        },
+      });
+      app.prepare({}, function (env) {
+        expect(env.config).toEqual({
+          'expand-homedir-config': {
+            aaa: 'AAA', // Comes from the base, which overrode `aaa: 'CCC'` in the `extends`
+            bbb: 'BBB', // Comes from the `extends`
+          },
+        });
+        done();
+      });
+    });
+
     it('throws error on circular extends', function (done) {
       var app = new Liftoff({
         name: 'myapp',


### PR DESCRIPTION
This PR enables to use `~` at heading of `extends` propery in a config file.

By this modification, users can specify a config file in each home directory of members for `extends` of a config file in a project directory.