### PR TITLE
fix: Disallow non-string configPath overrides

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,9 @@ Liftoff.prototype.buildEnvironment = function (opts) {
   var configPathOverride = arrayFind(Object.keys(config), function (key) {
     var cfg = config[key];
     if (Object.prototype.hasOwnProperty.call(cfg, configName)) {
-      return cfg[configName];
+      if (typeof cfg[configName] === "string") {
+        return cfg[configName];
+      }
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -119,7 +119,9 @@ Liftoff.prototype.buildEnvironment = function (opts) {
     // resolve something like `{ gulpfile: "./abc.xyz" }` to the absolute path
     // based on the path of the configFile
     if (Object.prototype.hasOwnProperty.call(configFile, configName)) {
-      configFile[configName] = path.resolve(path.dirname(configFilePath), configFile[configName]);
+      if (typeof configFile[configName] === 'string') {
+        configFile[configName] = path.resolve(path.dirname(configFilePath), configFile[configName]);
+      }
     }
 
     visited[configFilePath] = true;

--- a/test/fixtures/configfiles/override-config-path-non-string.js
+++ b/test/fixtures/configfiles/override-config-path-non-string.js
@@ -1,0 +1,5 @@
+var path = require('path');
+
+module.exports = {
+  myappfile: {},
+};

--- a/test/index.js
+++ b/test/index.js
@@ -601,6 +601,21 @@ describe('Liftoff', function () {
       });
     });
 
+    it('ignores non-string configPath if the configName key exists in the config', function (done) {
+      var app = new Liftoff({
+        name: 'myapp',
+        configFiles: {
+          'override-config-path-non-string': [
+            { path: 'test/fixtures/configfiles', extensions: ['.js'] }
+          ],
+        },
+      });
+      app.prepare({}, function (env) {
+        expect(env.configPath).toMatch(null);
+        done();
+      });
+    });
+
     it('should use dirname of configPath if no cwd is specified', function (done) {
       var app = new Liftoff({
         name: 'myapp',

--- a/test/index.js
+++ b/test/index.js
@@ -611,7 +611,7 @@ describe('Liftoff', function () {
         },
       });
       app.prepare({}, function (env) {
-        expect(env.configPath).toMatch(null);
+        expect(env.configPath).toEqual(null);
         done();
       });
     });


### PR DESCRIPTION
I noticed a bug here.