### PR TITLE
feat!: Populate additional preload modules with `configFiles`

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,10 @@ All `extends` properties will be traversed and become the basis for the resultin
 
 Users can override the `configPath` via their config files by specifying a field with the same name as the primary `configName`. For example, the `hackerfile` property in a `configFile` will resolve the `configPath` and `configBase` against the path.
 
+### `preload`
+
+If specified as a string or array of strings, they will be added to the list of preloads in the environment.
+
 ## Examples
 
 Check out how [gulp][gulp-cli-index] uses Liftoff.

--- a/test/fixtures/configfiles/preload-array.js
+++ b/test/fixtures/configfiles/preload-array.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preload: ['abc', 'xyz']
+};

--- a/test/fixtures/configfiles/preload-invalid-array.js
+++ b/test/fixtures/configfiles/preload-invalid-array.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preload: [{}, 123, 'no']
+};

--- a/test/fixtures/configfiles/preload-invalid.js
+++ b/test/fixtures/configfiles/preload-invalid.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preload: {}
+};

--- a/test/fixtures/configfiles/preload-string.js
+++ b/test/fixtures/configfiles/preload-string.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preload: 'abc'
+};

--- a/test/index.js
+++ b/test/index.js
@@ -616,6 +616,100 @@ describe('Liftoff', function () {
       });
     });
 
+    it('adds array of preloads specified in config', function (done) {
+      var app = new Liftoff({
+        name: 'myapp',
+        configFiles: {
+          'preload-array': [
+            { path: 'test/fixtures/configfiles', extensions: ['.js'] }
+          ],
+        },
+      });
+      app.prepare({}, function (env) {
+        expect(env.preload).toEqual(['abc', 'xyz']);
+        done();
+      });
+    });
+
+    it('combines array of preloads specified in config', function (done) {
+      var app = new Liftoff({
+        name: 'myapp',
+        configFiles: {
+          'preload-array': [
+            { path: 'test/fixtures/configfiles', extensions: ['.js'] }
+          ],
+        },
+      });
+      app.prepare({
+        preload: ['123']
+      }, function (env) {
+        expect(env.preload).toEqual(['123', 'abc', 'xyz']);
+        done();
+      });
+    });
+
+    it('adds string preload specified in config', function (done) {
+      var app = new Liftoff({
+        name: 'myapp',
+        configFiles: {
+          'preload-string': [
+            { path: 'test/fixtures/configfiles', extensions: ['.js'] }
+          ],
+        },
+      });
+      app.prepare({}, function (env) {
+        expect(env.preload).toEqual(['abc']);
+        done();
+      });
+    });
+
+    it('combines string preload specified in config', function (done) {
+      var app = new Liftoff({
+        name: 'myapp',
+        configFiles: {
+          'preload-string': [
+            { path: 'test/fixtures/configfiles', extensions: ['.js'] }
+          ],
+        },
+      });
+      app.prepare({
+        preload: ['xyz']
+      }, function (env) {
+        expect(env.preload).toEqual(['xyz', 'abc']);
+        done();
+      });
+    });
+
+    it('ignores non-string/non-array preload specified in config', function (done) {
+      var app = new Liftoff({
+        name: 'myapp',
+        configFiles: {
+          'preload-invalid': [
+            { path: 'test/fixtures/configfiles', extensions: ['.js'] }
+          ],
+        },
+      });
+      app.prepare({}, function (env) {
+        expect(env.preload).toEqual([]);
+        done();
+      });
+    });
+
+    it('ignores array with any non-strings preload specified in config', function (done) {
+      var app = new Liftoff({
+        name: 'myapp',
+        configFiles: {
+          'preload-invalid-array': [
+            { path: 'test/fixtures/configfiles', extensions: ['.js'] }
+          ],
+        },
+      });
+      app.prepare({}, function (env) {
+        expect(env.preload).toEqual([]);
+        done();
+      });
+    });
+
     it('should use dirname of configPath if no cwd is specified', function (done) {
       var app = new Liftoff({
         name: 'myapp',


### PR DESCRIPTION
As per @sttk requested in #128, this adds `preloads` to the `env` if they exist in the config.