### PR TITLE
fix: Avoid pass a null value to existsSync

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [10, 12, 14, 16, 18, 20, 22, 24]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
 
     steps:
       - name: Clone repository

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14, 16]
+        node: [10, 12, 14, 16, 18, 20, 22, 24]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/lib/find_config.js
+++ b/lib/find_config.js
@@ -20,7 +20,8 @@ module.exports = function (opts) {
     configPath = fileSearch(configNameSearch, searchPaths);
   }
   // confirm the configPath exists and return an absolute path to it
-  if (fs.existsSync(configPath)) {
+  // Skip the call to fs.existsSync if configPath is null
+  if (configPath && fs.existsSync(configPath)) {
     return path.resolve(configPath);
   }
   return null;


### PR DESCRIPTION
This fixes a deprecation warning in Node.js 24 when a `null` value was passed to `fs.existsSync`.